### PR TITLE
Add esp-wrover-kit to platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,17 @@ build_flags =
     -D CORE_DEBUG_LEVEL=4
     ;-D DEV_SETUP=0
 
+
+[env:esp-wrover-kit]
+platform = espressif32
+board = esp-wrover-kit
+framework = espidf
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+monitor_speed = 115200
+test_ignore = test_desktop
+board_build.partitions = partitions_custom.csv
+
 [env:featheresp32]
 platform = espressif32
 board = featheresp32


### PR DESCRIPTION
[esp-wrover-kit](https://www.espressif.com/en/products/hardware/esp-wrover-kit/overview) will be the development board for the development team in the next weeks