### PR TITLE
sdkconfig: disable C++ exceptions

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -21,12 +21,6 @@ CONFIG_SPIRAM_TYPE_AUTO=y
 # end of SPI RAM options
 
 #
-# Compiler options
-#
-CONFIG_COMPILER_CXX_EXCEPTIONS=y
-# end of Compiler Options
-
-#
 # HTTPS Server Config
 #
 CONFIG_ESP_HTTPS_SERVER_ENABLE=y

--- a/test/sdkconfig.defaults
+++ b/test/sdkconfig.defaults
@@ -12,12 +12,6 @@ CONFIG_PARTITION_TABLE_FILENAME="../partitions_custom.csv"
 # end of Partition Table
 
 #
-# Compiler options
-#
-CONFIG_COMPILER_CXX_EXCEPTIONS=y
-# end of Compiler Options
-
-#
 # HTTPS Server Config
 #
 CONFIG_ESP_HTTPS_SERVER_ENABLE=y


### PR DESCRIPTION
Disables exceptions on C++ code.

Closes #114 