### PR TITLE
turpial-firmware: enable RTR_ADV for esp_wifi_ap

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,15 @@
+menu "Turpial Firmware configuration"
+
+config TURPIAL_GLOBAL_ADDR
+    string "Turpial default IPv6 global address"
+    default "2001:db8::1"
+    help
+        Turpial default IPv6 global address
+
+config TURPIAL_GLOBAL_PREFIX
+    int "Prefix in bits for Turpial global address"
+    default 64
+    help
+        Global prefix in bits for Turpial global address
+
+endmenu

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ USEMODULE += gnrc_udp
 USEMODULE += gnrc_pktdump
 USEMODULE += gnrc_icmpv6_echo
 
+USEMODULE += netstats_l2
+USEMODULE += netstats_ipv6
+
 USEMODULE += shell
 USEMODULE += shell_commands
 

--- a/main.c
+++ b/main.c
@@ -8,8 +8,12 @@
 
 #include <stdio.h>
 
+#include "net/netif.h"
+
 #include "shell.h"
 #include "msg.h"
+
+#define ESP_WIFI_AP_NAME "8"
 
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
@@ -20,6 +24,18 @@ int main(void)
 
     if (!IS_ACTIVE(MODULE_ESP_WIFI_AP)) {
         printf("Error: dear user, you need a network interface to access the mesh :=)\n");
+    }
+
+    netif_t *wifi_iface = netif_get_by_name(ESP_WIFI_AP_NAME);
+    if (wifi_iface == NULL) {
+        printf("Error: ESP32 WiFi SoftAP interface doesn't exists.\n");
+    }
+    else {
+        netopt_enable_t set = NETOPT_ENABLE;
+        if (netif_set_opt(wifi_iface, NETOPT_IPV6_SND_RTR_ADV, 0, &set,
+                          sizeof(netopt_enable_t)) < 0) {
+            printf("Error: Couldn't set RTR_ADV flag on ESP32 SoftAP\n");
+        }
     }
 
     /* we need a message queue for the thread running the shell in order to

--- a/main.c
+++ b/main.c
@@ -16,11 +16,15 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 int main(void)
 {
+    puts("Welcome to Turpial ESP32 MCU!");
+
+    if (!IS_ACTIVE(MODULE_ESP_WIFI_AP)) {
+        printf("Error: dear user, you need a network interface to access the mesh :=)\n");
+    }
+
     /* we need a message queue for the thread running the shell in order to
      * receive potentially fast incoming networking packets */
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
-
-    puts("Welcome to Turpial ESP32 MCU!");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     /* Start shell */

--- a/main.c
+++ b/main.c
@@ -1,13 +1,18 @@
 /**
+ * @defgroup    main
+ * @ingroup     main
+ *
  * @{
+ *
  * @file
- * @author      Locha Mesh Developers (contact@locha.io)
  * @brief       Main firmware file
+ * @author      Locha Mesh Developers (contact@locha.io)
  * @}
  */
 
 #include <stdio.h>
 
+#include "net/gnrc/netif.h"
 #include "net/netif.h"
 
 #include "shell.h"
@@ -31,6 +36,19 @@ int main(void)
         printf("Error: ESP32 WiFi SoftAP interface doesn't exists.\n");
     }
     else {
+        ipv6_addr_t addr;
+        if (ipv6_addr_from_str(&addr, CONFIG_TURPIAL_GLOBAL_ADDR) == NULL) {
+            printf("Error: Invalid address");
+        }
+
+        uint16_t flags = GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID |
+                         (CONFIG_TURPIAL_GLOBAL_PREFIX << 8);
+        if (netif_set_opt(wifi_iface, NETOPT_IPV6_ADDR, flags, &addr,
+                          sizeof(addr)) < 0) {
+            printf("Error: Couldn't add global IPv6 address");
+        }
+
+        /* Set the RTR_ADV flag */
         netopt_enable_t set = NETOPT_ENABLE;
         if (netif_set_opt(wifi_iface, NETOPT_IPV6_SND_RTR_ADV, 0, &set,
                           sizeof(netopt_enable_t)) < 0) {


### PR DESCRIPTION
This is a work ~in progress~ to enable the RTR_ADV flag on the ESP32 AP.