### PR TITLE
turpial-firmware: add slipdev interface.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,19 @@ USEMODULE += shell_commands
 
 USEMODULE += esp_wifi_ap
 
+USEMODULE += slipdev
+
+UART1_TXD ?= "GPIO21"
+UART1_RXD ?= "GPIO22"
+
+# UART_DEV(1) pin definitions, can't be changed through Kconfig
+# TODO: open issue in RIOT to see if this is possible.
+CFLAGS += "-DUART1_TXD=$(UART1_TXD)"
+CFLAGS += "-DUART1_RXD=$(UART1_RXD)"
+
+# Use UART_DEV(1) for slipdev as a default, baudrate by default is 115200
+SLIP_UART ?= 1
+CFLAGS += "-DSLIPDEV_PARAM_UART=UART_DEV($(SLIP_UART))"
+
 include $(RIOTBASE)/Makefile.include
 

--- a/main.c
+++ b/main.c
@@ -23,6 +23,17 @@
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
+static int board_config_cmd(int argc, char **argv)
+{
+    print_board_config();
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "board_config", "print board configuration", board_config_cmd },
+    { NULL, NULL, NULL }
+};
+
 int main(void)
 {
     puts("Welcome to Turpial ESP32 MCU!");
@@ -62,7 +73,7 @@ int main(void)
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     /* Start shell */
-    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* Should be never reached */
     return 0;


### PR DESCRIPTION
Adds the`slipdev` network interface used to communicate with the CC1312, adds the `board_config` command to print board configuration (to know which pins are used for the slipdev interface).