### PR TITLE
boards: add turpial-esp32 

### DIFF
--- a/boards/turpial-esp32/Kconfig
+++ b/boards/turpial-esp32/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "turpial-esp32" if BOARD_TURPIAL_ESP32
+
+config BOARD_TURPIAL_ESP32
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROVER
+    select HAS_ESP_RTC_TIMER_32K
+    select HAS_ESP_SPI_RAM
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_ARDUINO
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/turpial-esp32/Makefile
+++ b/boards/turpial-esp32/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/turpial-esp32/Makefile.dep
+++ b/boards/turpial-esp32/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/esp32/Makefile.dep

--- a/boards/turpial-esp32/Makefile.features
+++ b/boards/turpial-esp32/Makefile.features
@@ -1,0 +1,16 @@
+CPU_MODEL = esp32-wrover
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32/Makefile.features
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+
+# unique features provided by the board
+FEATURES_PROVIDED += esp_spi_ram
+FEATURES_PROVIDED += esp_rtc_timer_32k
+
+FEATURES_PROVIDED += arduino

--- a/boards/turpial-esp32/Makefile.include
+++ b/boards/turpial-esp32/Makefile.include
@@ -1,0 +1,4 @@
+# configure the serial interface
+PORT_LINUX ?= /dev/ttyUSB1
+
+include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/turpial-esp32/include/arduino_board.h
+++ b/boards/turpial-esp32/include/arduino_board.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C)  2018 Gunar Schorcht
+ * Copyright (C)  2020 Locha Mesh Developers
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_turpial_esp32
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Locha Mesh Developers <contact@locha.io>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is not available
+ */
+#define ARDUINO_LED         (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/turpial-esp32/include/arduino_pinmap.h
+++ b/boards/turpial-esp32/include/arduino_pinmap.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C)  2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_esp-wrover-kit
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0   GPIO3       /**< Arduino Uno pin 0 (RxD) */
+#define ARDUINO_PIN_1   GPIO1       /**< Arduino Uno pin 1 (TxD) */
+
+#define ARDUINO_PIN_2   GPIO19      /**< Arduino Uno pin 2 */
+#define ARDUINO_PIN_3   GPIO0       /**< Arduino Uno pin 3 (PWM) */
+#define ARDUINO_PIN_4   GPIO22      /**< Arduino Uno pin 4 */
+#define ARDUINO_PIN_5   GPIO4       /**< Arduino Uno pin 5 (PWM) */
+#define ARDUINO_PIN_6   GPIO23      /**< Arduino Uno pin 6 (PWM) */
+#define ARDUINO_PIN_7   GPIO25      /**< Arduino Uno pin 7 */
+#define ARDUINO_PIN_8   GPIO9       /**< Arduino Uno pin 8 */
+#define ARDUINO_PIN_9   GPIO10      /**< Arduino Uno pin 9 (PWM) */
+
+#define ARDUINO_PIN_10  GPIO13      /**< Arduino Uno pin 10 (CS0 / PWM)  */
+#define ARDUINO_PIN_11  GPIO15      /**< Arduino Uno pin 11 (MOSI / PWM) */
+#define ARDUINO_PIN_12  GPIO2       /**< Arduino Uno pin 12 (MISO) */
+#define ARDUINO_PIN_13  GPIO14      /**< Arduino Uno pin 13 (SCK)  */
+
+#define ARDUINO_PIN_A0  GPIO34      /**< Arduino Uno pin A0 */
+#define ARDUINO_PIN_A1  GPIO35      /**< Arduino Uno pin A1 */
+#define ARDUINO_PIN_A2  GPIO36      /**< Arduino Uno pin A2 */
+#define ARDUINO_PIN_A3  GPIO39      /**< Arduino Uno pin A3 */
+
+#define ARDUINO_PIN_A4  GPIO26      /**< Arduino Uno pin A4 (SDA) */
+#define ARDUINO_PIN_A5  GPIO27      /**< Arduino Uno pin A5 (SCL) */
+/** @ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/turpial-esp32/include/board.h
+++ b/boards/turpial-esp32/include/board.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Locha Mesh Developers
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_turpial_esp32
+ * @brief       Board specific definitions for the ESP32 of the Locha Mesh Turpial.
+ * @{
+ *
+ * @file
+ * @author      Locha Mesh Developers <contact@locha.io>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize the board specific hardware
+ */
+static inline void board_init(void) {
+    /* there is nothing special to initialize on this board */
+    board_init_common();
+}
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/turpial-esp32/include/periph_conf.h
+++ b/boards/turpial-esp32/include/periph_conf.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2020 Locha Mesh Developers
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_turpial_esp32
+ * @brief       Peripheral MCU configuration for the ESP32 of the Locha Mesh Turpial.
+ * @{
+ *
+ * @file
+ * @author      Locha Mesh Developers <contact@locha.iot>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * When the camera is connected there are no GPIOs left that could be used
+ * as ADC channels.
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the ```adc_init``` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { GPIO34, GPIO35 }
+#endif
+
+/**
+ * @brief   Declaration of GPIOs that can be used as DAC channels
+ *
+ * Turpial has no GPIOs left that might be used as DAC channels.
+ */
+#ifndef DAC_GPIOS
+#define DAC_GPIOS   { }
+#endif
+/** @} */
+
+
+/**
+ * @name   I2C configuration
+ *
+ * @note The GPIOs listed in the configuration are only initialized as I2C
+ * signals when module ```perpih_i2c``` is used. Otherwise they are not
+ * allocated and can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO27          /**< SCL signal of I2C_DEV(0) [UEXT1] */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO26          /**< SDA signal of I2C_DEV(0) [UEXT1] */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * LEDs are used as PWM channels for device PWM_DEV(0).
+ *
+ * @note As long as the according PWM device is not initialized with function
+ * pwm_init, the GPIOs declared for this device can be used for other
+ * purposes.
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the ```pwm_init```, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+#ifndef PWM0_GPIOS
+#define PWM0_GPIOS  { }
+#endif
+
+/** PWM_DEV(1) is not used */
+#ifndef PWM1_GPIOS
+#define PWM1_GPIOS  { }
+#endif
+/** @} */
+
+
+/**
+ * @name    SPI configuration
+ *
+ * SPI configuration depends on configured/connected components.
+ *
+ * HSPI is is always available and therefore used as SPI_DEV(0)
+ * VSPI is only available when the camera is not plugged.
+ *
+ * @{
+ */
+
+#ifndef SPI0_CTRL
+#define SPI0_CTRL   HSPI    /**< HSPI is configured as SPI_DEV(0) */
+#endif
+
+#ifndef SPI0_SCK
+#define SPI0_SCK    GPIO14
+#endif
+#ifndef SPI0_MOSI
+#define SPI0_MOSI   GPIO15
+#endif
+#ifndef SPI0_MISO
+#define SPI0_MISO   GPIO2
+#endif
+#ifndef SPI0_CS0
+#define SPI0_CS0    GPIO13  /**< SD Card CS */
+#endif
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32 provides 3 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not available.<br>
+ * UART_DEV(2) is not available.<br>
+ * @{
+ */
+#define UART0_TXD   GPIO1   /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO3   /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+#define UART1_TXD   GPIO21  /**< direct I/O pin for UART_DEV(1) TxD, can't be changed */
+#define UART1_RXD   GPIO22  /**< direct I/O pin for UART_DEV(1) RxD, can't be changed */
+/** @} */
+
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common board definitions as last step */
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/wifi/Makefile
+++ b/wifi/Makefile
@@ -1,25 +1,15 @@
-# name of your application
 APPLICATION = wifi-subsys
 
-# If no BOARD is found in the environment, use this default:
-BOARD ?= esp32-wrover-kit
-EXTERNAL_BOARD_DIRS ?= $(CURDIR)/boards
+EXTERNAL_BOARD_DIRS += $(CURDIR)/../boards
+EXTERNAL_MODULE_DIRS += sys
 
-# This has to be the absolute path to the RIOT base directory:
+BOARD ?= turpial-esp32
+
 RIOTBASE ?= $(CURDIR)/../RIOT
-
-# Application absolute path
 APPBASE ?= $(CURDIR)
 
-# Comment this out to disable code in RIOT that does safety checking
-# which is not needed in a production environment but helps in the
-# development process:
 DEVELHELP ?= 1
-
-# Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
-
-EXTERNAL_MODULE_DIRS += sys
 
 # Initialize GNRC netif
 USEMODULE += gnrc_netdev_default
@@ -44,14 +34,6 @@ USEMODULE += cjson
 USEMODULE += nvs
 USEMODULE += wifi_settings
 USEMODULE += slipdev
-
-UART1_TXD ?= "GPIO21"
-UART1_RXD ?= "GPIO22"
-
-# UART_DEV(1) pin definitions, can't be changed through Kconfig
-# TODO: open issue in RIOT to see if this is possible.
-CFLAGS += "-DUART1_TXD=$(UART1_TXD)"
-CFLAGS += "-DUART1_RXD=$(UART1_RXD)"
 
 CFLAGS += "-DESP_WIFI_CHANNEL=1"
 


### PR DESCRIPTION
Adds the board for the ESP32 found on the Turpial board.

Depends on #177 