### PR TITLE
wifi: add WiFi SSID/Password to Kconfig

### DIFF
--- a/wifi/Kconfig
+++ b/wifi/Kconfig
@@ -1,5 +1,18 @@
 menu "Turpial Firmware configuration"
 
+config TURPIAL_AP_SSID
+    string "Turpial AP SSID"
+    default "Turpial_"
+    help
+        Turpial AP SSID. If not specified, by default an SSID of
+        Turpial_<ESP32 MAC> will be used.
+
+config TURPIAL_AP_PASSWORD
+    string "Turpial AP password"
+    default "mypassword"
+    help
+        Turpial AP password.
+
 config TURPIAL_GLOBAL_ADDR
     string "Turpial default IPv6 global address"
     default "2001:db8::1"

--- a/wifi/Makefile
+++ b/wifi/Makefile
@@ -43,3 +43,17 @@ SLIP_UART ?= 1
 CFLAGS += "-DSLIPDEV_PARAM_UART=UART_DEV($(SLIP_UART))"
 
 include $(RIOTBASE)/Makefile.include
+
+# esp32 cpu doesn't support a netopt for WiFi SSID (yet) nor Kconfig.
+# TODO: fix this on RIOT.
+ifneq ("Turpial_",$(CONFIG_TURPIAL_AP_SSID))
+  CFLAGS += -DESP_WIFI_AP_SSID=\"$(CONFIG_TURPIAL_AP_SSID)\"
+else
+  CFLAGS += -DESP_WIFI_AP_PREFIX=\"Turpial_\"
+endif
+
+ifneq ("mypassword",$(CONFIG_TURPIAL_AP_PASSWORD))
+  CFLAGS += -DESP_WIFI_PASS=\"$(CONFIG_TURPIAL_AP_PASSWORD)\"
+else
+  CFLAGS += -DESP_WIFI_PASS=\"mypassword\"
+endif


### PR DESCRIPTION
We can now use a custom SSID or password without adding additional defines, just `make menuconfig`, and by default if no
SSID is specified the `Turpial_` prefix will be used and the rest will be the MAC address of the AP.