### PR TITLE
search for mispelling errors on selected actions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,5 +14,5 @@ jobs:
             check_hidden: false
             skip: RIOT,*.svg,./core/contrib,.git
             # ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout
-            ignore_words_file: .dist/codespell/ignored_words.txt
+            ignore_words_file: ./dist/codespell/ignored_words.txt
             only_warn: 1

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,8 +9,8 @@ jobs:
         steps:
             - uses: actions/checkout@v1
             - uses: codespell-project/actions-codespell@master
-        with:
-            check_filenames: false
-            check_hidden: false
-            skip: RIOT,*.svg,./core/contrib,.git
-            ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout
+            with:
+                check_filenames: false
+                check_hidden: false
+                skip: RIOT,*.svg,./core/contrib,.git
+                ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,5 +14,5 @@ jobs:
             check_hidden: false
             skip: RIOT,*.svg,./core/contrib,.git
             # ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout
-            ignore_words_file: ./dist/codespell/ignored_words.txt
+            ignore_words_file: dist/codespell/ignored_words.txt
             only_warn: 1

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,14 +3,14 @@ name: Codespell
 on: [push, pull_request]
 
 jobs:
-    codespell:
-        name: Check for spelling errors
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v1
-            - uses: codespell-project/actions-codespell@master
-            with:
-                check_filenames: false
-                check_hidden: false
-                skip: RIOT,*.svg,./core/contrib,.git
-                ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: false
+          check_hidden: false
+          skip: RIOT,*.svg,./core/contrib,.git
+          ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,5 +14,5 @@ jobs:
             check_hidden: false
             skip: RIOT,*.svg,./core/contrib,.git
             # ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout
-            ignore_words_file: dist/codespell/ignored_words.txt
+            ignore_words_file: dist/tools/codespell/ignored_words.txt
             only_warn: 1

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,16 @@
+name: Codespell
+
+on: [push, pull_request]
+
+jobs:
+    codespell:
+        name: Check for spelling errors
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v1
+            - uses: codespell-project/actions-codespell@master
+        with:
+            check_filenames: false
+            check_hidden: false
+            skip: RIOT,*.svg,./core/contrib,.git
+            ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,6 @@ jobs:
             check_filenames: false
             check_hidden: false
             skip: RIOT,*.svg,./core/contrib,.git
-            ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout
+            # ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout
+            ignore_words_file: .dist/codespell/ignored_words.txt
+            only_warn: 1

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,7 +12,5 @@ jobs:
         with:
             check_filenames: false
             check_hidden: false
-            skip: RIOT,*.svg,./core/contrib,.git
-            # ignore_words_list: rsource,inout,doubleclick,crate,rsource,bufffer,trucated,calculate,childs,elments,continous,neigbor,Initalize,initalize,happend,inout
+            skip: RIOT, *.svg, core/contrib, .git
             ignore_words_file: dist/tools/codespell/ignored_words.txt
-            only_warn: 1

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -3,7 +3,7 @@ crate
 rsource
 bufffer
 trucated
-calulate
+calculate
 childs
 elments
 continous


### PR DESCRIPTION
# Codepell workflow 
Codespell will detect misspelling errors on selected actions such as push, merge, etc.

To avoid a false positive a file named as `dist/tools/codespell/ignored_words.txt` will be used as dictionary